### PR TITLE
Add a --force-colors switch

### DIFF
--- a/jut/__init__.py
+++ b/jut/__init__.py
@@ -69,6 +69,7 @@ class Config(BaseModel):
     tail: int
     single_page: bool
     full_display: bool
+    force_colors: bool
 
     @validator("input_file")
     def validate_input_file(cls, val):
@@ -147,7 +148,7 @@ class Render(FormatMixin):
         custom_theme = Theme(
             {"info": "dim cyan", "warning": "magenta", "danger": "bold red"}
         )
-        self.console = Console(theme=custom_theme)
+        self.console = Console(theme=custom_theme, force_terminal=config.force_colors)
 
     def parse_notebook(self):
         """Parse the notebook content."""

--- a/jut/cli.py
+++ b/jut/cli.py
@@ -52,7 +52,14 @@ def download_url(url):
     is_flag=True,
     help="Should all the contents in the file displayed?",
 )
-def display(url, input_file, head, tail, single_page, full_display):
+@click.option(
+    "--force-colors",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Force colored output even if stdout is not a terminal",
+)
+def display(url, input_file, head, tail, single_page, full_display, force_colors):
     destination_file = None
     if url:
         destination_file = download_url(url)
@@ -77,6 +84,7 @@ def display(url, input_file, head, tail, single_page, full_display):
             tail=tail,
             single_page=single_page,
             full_display=full_display,
+            force_colors=force_colors,
         )
         render = Render(config)
         render.render()


### PR DESCRIPTION
Thanks for this tool! After hearing about it, I immediately wanted to integrate it with [ranger](https://ranger.github.io/) so I can get previews in the file manager.

Unfortunately, rich has no way to force colors (https://github.com/willmcgugan/rich/issues/343) and disables them with ranger's preview integration because the output isn't a terminal.

Thus, I added a `--force-colors` switch to get them back:

![image](https://user-images.githubusercontent.com/625793/112191701-91476600-8c06-11eb-8a04-2794b927052b.png)

(it still requires setting `COLORTERM=8bit` in the environment to get proper 256color support)